### PR TITLE
End-to-end support for running all containers with: ./compose/start.sh -a

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ It uses `Celery workers to process all tasks <http://www.celeryproject.org/>`__ 
    :header-rows: 1
 
    * - `Build <https://travis-ci.org/AlgoTraders/stock-analysis-engine>`__
-     - `Docs <https://stock-analysis-engine.readthedocs.io/en/latest/>`__
+     - `Docs <https://stock-analysis-engine.readthedocs.io/en/latest/README.html>`__
    * - .. image:: https://api.travis-ci.org/AlgoTraders/stock-analysis-engine.svg
            :alt: Travis Tests
            :target: https://travis-ci.org/AlgoTraders/stock-analysis-engine
@@ -211,8 +211,54 @@ Redis Cache Set
 
     python -m unittest tests.test_publish_pricing_update.TestPublishPricingData.test_success_redis_set
 
-Integration Tests
-=================
+End-to-End Integration Testing
+==============================
+
+Start all the containers for full end-to-end integration testing with real docker containers with the script:
+
+::
+
+    ./compose/start.sh -a
+    -------------
+    starting end-to-end integration stack: redis, minio, workers and jupyter
+    Creating network "compose_default" with the default driver
+    Creating redis ... done
+    Creating minio ... done
+    Creating sa-jupyter ... done
+    Creating sa-workers ... done
+    started end-to-end integration stack: redis, minio, workers and jupyter
+
+Verify Containers are running:
+
+::
+
+    docker ps
+    CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS                    PORTS                    NAMES
+    f1b81a91c215        jayjohnson/stock-analysis-engine:latest   "/opt/antinex/core/d…"   35 seconds ago      Up 34 seconds                                      sa-jupyter
+    183b01928d1f        jayjohnson/stock-analysis-engine:latest   "/bin/sh -c 'cd /opt…"   35 seconds ago      Up 34 seconds                                      sa-workers
+    11d46bf1f0f7        minio/minio:latest                        "/usr/bin/docker-ent…"   36 seconds ago      Up 35 seconds (healthy)                            minio
+    9669494b49a2        redis:4.0.9-alpine                        "docker-entrypoint.s…"   36 seconds ago      Up 35 seconds             0.0.0.0:6379->6379/tcp   redis
+
+Stop End-to-End Stack:
+
+::
+
+    ./compose/stop.sh -a
+    -------------
+    stopping integration stack: redis, minio, workers and jupyter
+    Stopping sa-jupyter ... done
+    Stopping sa-workers ... done
+    Stopping minio      ... done
+    Stopping redis      ... done
+    Removing sa-jupyter ... done
+    Removing sa-workers ... done
+    Removing minio      ... done
+    Removing redis      ... done
+    Removing network compose_default
+    stopped end-to-end integration stack: redis, minio, workers and jupyter
+
+Integration UnitTests
+=====================
 
 .. note:: please start redis and minio before running these tests.
 

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,0 +1,26 @@
+version: '2'
+
+services:
+
+  # Redis
+  redis:
+    container_name: "redis"
+    hostname: redis
+    image: redis:4.0.9-alpine
+    ports:
+      - "6379:6379"
+
+  # Minio
+  minio:
+    container_name: "minio"
+    hostname: minio
+    image: minio/minio:latest
+    network_mode: "host"
+    environment:
+      - MINIO_ACCESS_KEY="trexaccesskey"
+      - MINIO_SECRET_KEY="trex123321"
+    ports:
+      - "9000:9000"
+    volumes:
+      - /data/minio/data:/data
+    command: "server /data"

--- a/compose/integration.yml
+++ b/compose/integration.yml
@@ -1,0 +1,58 @@
+version: '2'
+
+services:
+
+  # Redis
+  redis:
+    container_name: "redis"
+    hostname: redis
+    image: redis:4.0.9-alpine
+    ports:
+      - "6379:6379"
+
+  # Minio
+  minio:
+    container_name: "minio"
+    hostname: minio
+    image: minio/minio:latest
+    network_mode: "host"
+    environment:
+      - MINIO_ACCESS_KEY="trexaccesskey"
+      - MINIO_SECRET_KEY="trex123321"
+    ports:
+      - "9000:9000"
+    volumes:
+      - /data/minio/data:/data
+    command: "server /data"
+
+  # Stock Analysis Engine
+  sa-workers:
+    container_name: "sa-workers"
+    hostname: sa-workers
+    image: jayjohnson/stock-analysis-engine:latest
+    network_mode: "host"
+    depends_on:
+      - redis
+      - minio
+    entrypoint: "/bin/sh -c 'cd /opt/sa && 
+                 /opt/sa/start-workers.sh'"
+
+  # Jupyter notebooks, converted noteooks as presentation html slides, and tensorboard
+  sa-jupyter:
+    container_name: "sa-jupyter"
+    hostname: sa-jupyter
+    image: jayjohnson/stock-analysis-engine:latest
+    network_mode: "host"
+    depends_on:
+      - redis
+      - minio
+    environment:
+      - JUPYTER_PASS=admin
+      - SHARED_DIR=/opt/data
+      - BROKER_URL=redis://0.0.0.0:6379/6
+    ports:
+      - "8888:8888"
+      - "8889:8889"
+      - "8890:8890"
+      - "6006:6006"
+    entrypoint: "/opt/antinex/core/docker/jupyter/start-container.sh"

--- a/compose/minio.yml
+++ b/compose/minio.yml
@@ -1,0 +1,18 @@
+version: '2'
+
+services:
+
+  # Minio
+  minio:
+    container_name: "minio"
+    hostname: minio
+    image: minio/minio:latest
+    network_mode: "host"
+    environment:
+      - MINIO_ACCESS_KEY="trexaccesskey"
+      - MINIO_SECRET_KEY="trex123321"
+    ports:
+      - "9000:9000"
+    volumes:
+      - /data/minio/data:/data
+    command: "server /data"

--- a/compose/stop.sh
+++ b/compose/stop.sh
@@ -40,9 +40,9 @@ done
 
 anmt "-------------"
 if [[ "${compose}" == "dev.yml" ]]; then
-    inf "starting redis and minio"
+    inf "stopping redis and minio"
 elif [[ "${compose}" == "integration.yml" ]]; then
-    inf "starting end-to-end integration stack: redis, minio, workers and jupyter"
+    inf "stopping integration stack: redis, minio, workers and jupyter"
 else
     err "unsupported compose file: ${compose}"
     exit 1
@@ -52,16 +52,16 @@ if [[ ! -e ./${compose} ]]; then
     pushd compose >> /dev/null
     down_dir="1"
 fi
-docker-compose -f ./${compose} up -d
+docker-compose -f ./${compose} down
 
 if [[ "${down_dir}" == "1" ]]; then
     popd >> /dev/null
 fi
 
 if [[ "${compose}" == "dev.yml" ]]; then
-    good "started redis and minio"
+    good "stopped redis and minio"
 elif [[ "${compose}" == "integration.yml" ]]; then
-    good "started end-to-end integration stack: redis, minio, workers and jupyter"
+    good "stopped end-to-end integration stack: redis, minio, workers and jupyter"
 fi
 
 exit 0

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -9,7 +9,7 @@ It uses `Celery workers to process all tasks <http://www.celeryproject.org/>`__ 
    :header-rows: 1
 
    * - `Build <https://travis-ci.org/AlgoTraders/stock-analysis-engine>`__
-     - `Docs <https://stock-analysis-engine.readthedocs.io/en/latest/>`__
+     - `Docs <https://stock-analysis-engine.readthedocs.io/en/latest/README.html>`__
    * - .. image:: https://api.travis-ci.org/AlgoTraders/stock-analysis-engine.svg
            :alt: Travis Tests
            :target: https://travis-ci.org/AlgoTraders/stock-analysis-engine
@@ -211,8 +211,54 @@ Redis Cache Set
 
     python -m unittest tests.test_publish_pricing_update.TestPublishPricingData.test_success_redis_set
 
-Integration Tests
-=================
+End-to-End Integration Testing
+==============================
+
+Start all the containers for full end-to-end integration testing with real docker containers with the script:
+
+::
+
+    ./compose/start.sh -a
+    -------------
+    starting end-to-end integration stack: redis, minio, workers and jupyter
+    Creating network "compose_default" with the default driver
+    Creating redis ... done
+    Creating minio ... done
+    Creating sa-jupyter ... done
+    Creating sa-workers ... done
+    started end-to-end integration stack: redis, minio, workers and jupyter
+
+Verify Containers are running:
+
+::
+
+    docker ps
+    CONTAINER ID        IMAGE                                     COMMAND                  CREATED             STATUS                    PORTS                    NAMES
+    f1b81a91c215        jayjohnson/stock-analysis-engine:latest   "/opt/antinex/core/d…"   35 seconds ago      Up 34 seconds                                      sa-jupyter
+    183b01928d1f        jayjohnson/stock-analysis-engine:latest   "/bin/sh -c 'cd /opt…"   35 seconds ago      Up 34 seconds                                      sa-workers
+    11d46bf1f0f7        minio/minio:latest                        "/usr/bin/docker-ent…"   36 seconds ago      Up 35 seconds (healthy)                            minio
+    9669494b49a2        redis:4.0.9-alpine                        "docker-entrypoint.s…"   36 seconds ago      Up 35 seconds             0.0.0.0:6379->6379/tcp   redis
+
+Stop End-to-End Stack:
+
+::
+
+    ./compose/stop.sh -a
+    -------------
+    stopping integration stack: redis, minio, workers and jupyter
+    Stopping sa-jupyter ... done
+    Stopping sa-workers ... done
+    Stopping minio      ... done
+    Stopping redis      ... done
+    Removing sa-jupyter ... done
+    Removing sa-workers ... done
+    Removing minio      ... done
+    Removing redis      ... done
+    Removing network compose_default
+    stopped end-to-end integration stack: redis, minio, workers and jupyter
+
+Integration UnitTests
+=====================
 
 .. note:: please start redis and minio before running these tests.
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ sys.path.insert(
 setup(
     name='stock-analysis-engine',
     cmdclass={'build_py': build_py},
-    version='1.0.1',
+    version='1.0.2',
     description=(
         'Stock Analysis Engine - '
         'Use this to get pricing data for tickers '


### PR DESCRIPTION
upgraded support for running all containers with:

```
./compose/start.sh -a
```