### PR TITLE
fix on mac where the PM transition on dates caused wrapping to 12 AM …

### DIFF
--- a/analysis_engine/consts.py
+++ b/analysis_engine/consts.py
@@ -294,8 +294,9 @@ PLOT_COLORS = {
 }
 
 IEX_DAILY_DATE_FORMAT = '%Y-%b-%d'
-IEX_MINUTE_DATE_FORMAT = '%Y-%m-%d %H:%M %p'
-IEX_TICK_DATE_FORMAT = '%Y-%m-%d %H:%M:%S %p'
+IEX_MINUTE_DATE_FORMAT = '%Y-%m-%d %I:%M:%S %p'
+IEX_TICK_DATE_FORMAT = '%Y-%m-%d %I:%M:%S %p'
+COMMON_TICK_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 
 ########################################

--- a/docs/source/scrub_utils.rst
+++ b/docs/source/scrub_utils.rst
@@ -1,2 +1,2 @@
 .. automodule:: analysis_engine.dataset_scrub_utils
-   :members: debug_msg,ingress_scrub_dataset,extract_scrub_dataset
+   :members: debug_msg,ingress_scrub_dataset,extract_scrub_dataset,build_dates_from_df_col

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ sys.path.insert(
 setup(
     name='stock-analysis-engine',
     cmdclass={'build_py': build_py},
-    version='1.0.19',
+    version='1.0.20',
     description=(
         'Stock Analysis Engine - '
         'Use this to get pricing data for tickers '


### PR DESCRIPTION
…instead of noon... impacted the minute feed so far, but could be more. made a separate date-string column function build_dates_from_df_col to reduce the number of custom handling in the future. date scrubbing + normalizing is always fun. looks like the price + volume overly timeseries chart works on mac. checking ubuntu next