### PR TITLE
turning s3 back on for intraday + daily + weekly jobs because it's causing a bug where these jobs do not respect this feature flag and try to publish s3 minio anyway with bad credentials and it causes timeouts that slow these jobs down too much for recording per minute.

### DIFF
--- a/helm/ae-daily/values.yaml
+++ b/helm/ae-daily/values.yaml
@@ -132,7 +132,7 @@ daily:
     pullPolicy: Always
   label: ""
   s3:
-    enabled: false
+    enabled: true
     name: minio
     secretName: ae.k8.minio.s3.daily
   redis:

--- a/helm/ae-intraday/values.yaml
+++ b/helm/ae-intraday/values.yaml
@@ -132,7 +132,7 @@ intraday:
     pullPolicy: Always
   label: ""
   s3:
-    enabled: false
+    enabled: true
     name: minio
     secretName: ae.k8.minio.s3.intraday
   redis:

--- a/helm/ae-weekly/values.yaml
+++ b/helm/ae-weekly/values.yaml
@@ -132,7 +132,7 @@ weekly:
     pullPolicy: Always
   label: ""
   s3:
-    enabled: false
+    enabled: true
     name: minio
     secretName: ae.k8.minio.s3.weekly
   redis:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ sys.path.insert(
 setup(
     name='stock-analysis-engine',
     cmdclass={'build_py': build_py},
-    version='1.9.6',
+    version='1.9.7',
     description=(
         'Backtest 1000s of minute-by-minute '
         'trading algorithms. Automated '


### PR DESCRIPTION
… 